### PR TITLE
[fix] spurious require statements

### DIFF
--- a/packages/pnpmfile/src/requirePnpmfile.ts
+++ b/packages/pnpmfile/src/requirePnpmfile.ts
@@ -1,8 +1,8 @@
 import PnpmError from '@pnpm/error'
 import logger from '@pnpm/logger'
 import { PackageManifest } from '@pnpm/types'
-import fs = require('fs')
-import chalk = require('chalk')
+import fs from 'fs'
+import chalk from 'chalk'
 import requireOrImport from '../requireOrImport.js'
 
 export class BadReadPackageHookError extends PnpmError {


### PR DESCRIPTION
Fixed requires for 'fs' and 'chalk' to imports.